### PR TITLE
Fixed calling client-only method for backpack colors in getSubItems (Fix for #23)

### DIFF
--- a/src/main/java/v0id/vsb/item/ItemBackpack.java
+++ b/src/main/java/v0id/vsb/item/ItemBackpack.java
@@ -83,8 +83,16 @@ public class ItemBackpack extends Item implements IGUIOpenable
 
         for (EnumDyeColor dyeColor : EnumDyeColor.values())
         {
+            float[] dyeColorValues = dyeColor.getColorComponentValues();
+
+            int r = (int)(dyeColorValues[0] * 255.0F);
+            int g = (int)(dyeColorValues[1] * 255.0F);
+            int b = (int)(dyeColorValues[2] * 255.0F);
+
+            int finalColor = ((r << 8) + g << 8) + b;
+
             ItemStack is = new ItemStack(this, 1, 0);
-            IBackpack.of(is).createWrapper().setColor(dyeColor.getColorValue());
+            IBackpack.of(is).createWrapper().setColor(finalColor);
             items.add(is);
         }
     }


### PR DESCRIPTION
Instead of going with reflection ([as primetoxinz suggested](https://github.com/V0idWa1k3r/SmartBackpacks/issues/23#issue-365239193)), i've just reused [backpack dyeing code](https://github.com/V0idWa1k3r/SmartBackpacks/blob/a336e847e2e711cf174fd4ff851be4cbcabebdc9/src/main/java/v0id/vsb/recipe/RecipeDyeBackpack.java#L109-L111) with `getColorComponentValues()` method for getSubItems, which is available on both sides.