### PR TITLE
Add support for Demagnetize mod and conveyors

### DIFF
--- a/src/main/java/v0id/vsb/item/upgrade/UpgradeMagnet.java
+++ b/src/main/java/v0id/vsb/item/upgrade/UpgradeMagnet.java
@@ -58,7 +58,7 @@ public class UpgradeMagnet extends UpgradeFiltered
             }
 
             IFilter filter = IFilter.of(self.getSelf().getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).getStackInSlot(0));
-            List<EntityItem> items = pulsar.world.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pulsar.posX - 12, pulsar.posY - 6, pulsar.posZ - 12, pulsar.posX + 12, pulsar.posY + 6, pulsar.posZ + 12), e -> e != null && !e.isDead && (filter == null || filter.accepts(e.getItem())) && !this.hasSolegnoliaAround(e));
+            List<EntityItem> items = pulsar.world.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pulsar.posX - 12, pulsar.posY - 6, pulsar.posZ - 12, pulsar.posX + 12, pulsar.posY + 6, pulsar.posZ + 12), e -> e != null && !e.isDead && !(e.getEntityData() != null && e.getEntityData().hasKey("PreventRemoteMovement")) && (filter == null || filter.accepts(e.getItem())) && !this.hasSolegnoliaAround(e));
             items.forEach(e -> e.onCollideWithPlayer(player));
         }
     }


### PR DESCRIPTION
Immersive Engineering's conveyors (and [my Demagnetize mod](https://minecraft.curseforge.com/projects/demagnetize)) add the PreventRemoteMovement NBT tag to the item. This prevents them from being picked up by magnets.

By the way, while testing your mod in a dev environment, I found that the upgrade and inventory slots were getting merged clientside somehow, and it caused a crash a couple of times. I'm not sure if it's because I setup the dev environment wrong, or if it's a bug with the latest commits. It works fine on the released build. I've uploaded a crash log here: https://paste.ee/p/jWMks.