### PR TITLE
Disallow ItemStackHandler to assume amount of slots

### DIFF
--- a/src/main/java/v0id/vsb/capability/Backpack.java
+++ b/src/main/java/v0id/vsb/capability/Backpack.java
@@ -342,10 +342,7 @@ public class Backpack implements IBackpack
                 }
             };
 
-            if (stack.hasTagCompound() && stack.getTagCompound().hasKey("vsb:nbtItemHandler"))
-            {
-                this.inventory.deserializeNBT(stack.getTagCompound().getCompoundTag("vsb:nbtItemHandler"));
-            }
+            this.deserializeFromStack();
         }
 
         @Override
@@ -354,17 +351,27 @@ public class Backpack implements IBackpack
             return this.slots;
         }
 
+        private void deserializeFromStack()
+        {
+            if (!this.stack.hasTagCompound() || !this.stack.getTagCompound().hasKey("vsb:nbtItemHandler", Constants.NBT.TAG_COMPOUND))
+            {
+                return;
+            }
+
+            this.isInitialized = true;
+
+            NBTTagCompound tag = this.stack.getTagCompound().getCompoundTag("vsb:nbtItemHandler");
+            tag.removeTag("Size");
+            this.inventory.deserializeNBT(this.stack.getTagCompound().getCompoundTag("vsb:nbtItemHandler"));
+        }
+
         @Nonnull
         @Override
         public ItemStack getStackInSlot(int slot)
         {
             if (!this.isInitialized)
             {
-                this.isInitialized = true;
-                if (this.stack.hasTagCompound() && this.stack.getTagCompound().hasKey("vsb:nbtItemHandler", Constants.NBT.TAG_COMPOUND))
-                {
-                    this.inventory.deserializeNBT(this.stack.getTagCompound().getCompoundTag("vsb:nbtItemHandler"));
-                }
+                this.deserializeFromStack();
             }
 
             return this.inventory.getStackInSlot(slot);
@@ -409,13 +416,16 @@ public class Backpack implements IBackpack
                 this.stack.setTagCompound(new NBTTagCompound());
             }
 
-            this.stack.getTagCompound().setTag("vsb:nbtItemHandler", this.inventory.serializeNBT());
+            NBTTagCompound tag = this.serializeNBT();
+            this.stack.getTagCompound().setTag("vsb:nbtItemHandler", tag);
         }
 
         @Override
         public NBTTagCompound serializeNBT()
         {
-            return this.inventory.serializeNBT();
+            NBTTagCompound tag = this.inventory.serializeNBT();
+            tag.removeTag("Size");
+            return tag;
         }
 
         @Override


### PR DESCRIPTION
This fixes heisenbug with slots amount being incorrect after backpack upgrade

```
Description: Ticking player

java.lang.RuntimeException: Slot 9 not in valid range - [0,9)
    at net.minecraftforge.items.ItemStackHandler.validateSlotIndex(ItemStackHandler.java:214)
    at net.minecraftforge.items.ItemStackHandler.getStackInSlot(ItemStackHandler.java:73)
    at v0id.vsb.capability.Backpack$NBTItemHandler.getStackInSlot(Backpack.java:370)
    at net.minecraftforge.items.SlotItemHandler.getStack(SlotItemHandler.java:73)
    at net.minecraft.inventory.Container.detectAndSendChanges(Container.java:79)
    at net.minecraft.entity.player.EntityPlayerMP.onUpdate(EntityPlayerMP.java:324)
    at net.minecraft.world.World.updateEntityWithOptionalForce(World.java:1993)
    at net.minecraft.world.WorldServer.updateEntityWithOptionalForce(WorldServer.java:832)
    at net.minecraft.world.World.updateEntity(World.java:1955)
    at net.minecraft.world.WorldServer.tickPlayers(WorldServer.java:642)
    at net.minecraft.world.World.updateEntities(World.java:1734)
    at net.minecraft.world.WorldServer.updateEntities(WorldServer.java:613)
    at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:767)
    at net.minecraft.server.dedicated.DedicatedServer.updateTimeLightAndEntities(DedicatedServer.java:397)
    at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:668)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
    at java.lang.Thread.run(Unknown Source)
```